### PR TITLE
Feat: 마이페이지 - 프로필수정 포지션 조회 등록 삭제 API 연결

### DIFF
--- a/src/components/mypage/edit/Desired.tsx
+++ b/src/components/mypage/edit/Desired.tsx
@@ -1,15 +1,41 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { CheckSquare, Square, Plus, Minus } from "lucide-react";
 import { locationData } from "../../../data/locationData";
 import SplitButton from "../../common/buttons/SplitButton";
 import CustomDropdown from "../../common/dropdowns/CustomDropdown";
-import { useGetPositions } from "../../../hooks/usePositions";
+import {
+  // useDeletePositions,
+  useGetPositions,
+  // usePostPositions,
+} from "../../../hooks/usePositions";
+import { useGetProfile } from "../../../hooks/useProfile";
+import { useProfileStore } from "../../../store/useProfileStore";
 
 const Desired = () => {
-  const { data } = useGetPositions();
+  const { data: allPositions } = useGetPositions(); // 옵션 목록
+  const { data: profile } = useGetProfile(); // 프로필(positions 포함)
+
+  //Store사용 전 코드
+  // // 포지션 정보 보내기
+  // const { mutate: postPosition, isPending: isPosting } = usePostPositions();
+  // //포지션 삭제하기
+  // const { mutate: deletePosition, isPending: isDeleting } =
+  //   useDeletePositions();
+
+  const positions = useProfileStore((s) => s.positions);
+  const setPositions = useProfileStore((s) => s.setPositions);
+  const setInitialPositions = useProfileStore((s) => s.setInitialPositions);
+  const togglePosition = useProfileStore((s) => s.togglePosition);
+
+  //최초 동기화 (프로필의 포지션으로)
+  useEffect(() => {
+    const serverPositions = profile?.result?.positions ?? [];
+    setInitialPositions(serverPositions);
+    setPositions(serverPositions);
+  }, [profile]);
 
   const [locations, setLocations] = useState([{ city: "", district: "" }]);
-  const [parts, setParts] = useState<string[]>([]);
+  // const [parts, setParts] = useState<string[]>([]);
   const [cityDropdownOpen, setCityDropdownOpen] = useState<
     Record<number, boolean>
   >({});
@@ -43,13 +69,36 @@ const Desired = () => {
     }
   };
 
-  const handlePartChange = (pos: string) => {
-    setParts((prevParts) =>
-      prevParts.includes(pos)
-        ? prevParts.filter((p) => p !== pos)
-        : [...prevParts, pos]
-    );
-  };
+  // const handlePartChange = (pos: string) => {
+  //   togglePosition(pos); // 상태만 토글
+  // };
+
+  // Store 사용 전 코드
+  // const handlePartChange = (pos: string) => {
+  //   // 중복 클릭 방지 (둘 중 하나라도 진행 중이면 무시)
+  //   if (isPosting || isDeleting) return;
+
+  //   const isSelected = parts.includes(pos); // 현재 렌더 상태로 판별
+
+  //   if (isSelected) {
+  //     // ✅ 삭제만 호출
+  //     deletePosition({
+  //       endpoint: `/api/v1/members/position?positionName=${encodeURIComponent(
+  //         pos
+  //       )}`,
+  //     });
+  //     // 낙관적 업데이트(원하면 성공 콜백에서 업데이트로 바꿔도 됨)
+  //     setParts(parts.filter((p) => p !== pos));
+  //   } else {
+  //     // ✅ 등록만 호출
+  //     postPosition({
+  //       endpoint: `/api/v1/members/position?positionName=${encodeURIComponent(
+  //         pos
+  //       )}`,
+  //     });
+  //     setParts([...parts, pos]);
+  //   }
+  // };
 
   const toggleCityDropdown = (index: number) => {
     setCityDropdownOpen((prev) => ({ ...prev, [index]: !prev[index] }));
@@ -169,13 +218,14 @@ const Desired = () => {
         <div className="grid grid-cols-5 gap-8 text-sm">
           {/* 기존 api로 position 가져오기 전 코드 */}
           {/* {["프론트엔드", "백엔드", "디자인", "기획", "홍보"].map((part) => ( */}
-          {data?.result.positions.map((pos) => (
+          {allPositions?.result.positions.map((pos) => (
             <div key={pos} className="flex items-center gap-2">
               <button
-                onClick={() => handlePartChange(pos)}
+                // onClick={() => handlePartChange(pos)}
+                onClick={() => togglePosition(pos)}
                 className="flex cursor-pointer items-center gap-2 text-gray-500 transition-all hover:scale-105"
               >
-                {parts.includes(pos) ? <CheckSquare /> : <Square />}
+                {positions.includes(pos) ? <CheckSquare /> : <Square />}
                 <span className="whitespace-nowrap">{pos}</span>
               </button>
             </div>

--- a/src/components/mypage/edit/Desired.tsx
+++ b/src/components/mypage/edit/Desired.tsx
@@ -1,40 +1,53 @@
-import { useState } from 'react';
-import { CheckSquare, Square, Plus, Minus } from 'lucide-react';
-import { locationData } from '../../../data/locationData';
-import SplitButton from '../../common/buttons/SplitButton';
-import CustomDropdown from '../../common/dropdowns/CustomDropdown';
+import { useState } from "react";
+import { CheckSquare, Square, Plus, Minus } from "lucide-react";
+import { locationData } from "../../../data/locationData";
+import SplitButton from "../../common/buttons/SplitButton";
+import CustomDropdown from "../../common/dropdowns/CustomDropdown";
+import { useGetPositions } from "../../../hooks/usePositions";
 
 const Desired = () => {
-  const [locations, setLocations] = useState([{ city: '', district: '' }]);
+  const { data } = useGetPositions();
+
+  const [locations, setLocations] = useState([{ city: "", district: "" }]);
   const [parts, setParts] = useState<string[]>([]);
-  const [cityDropdownOpen, setCityDropdownOpen] = useState<Record<number, boolean>>({});
-  const [districtDropdownOpen, setDistrictDropdownOpen] = useState<Record<number, boolean>>({});
+  const [cityDropdownOpen, setCityDropdownOpen] = useState<
+    Record<number, boolean>
+  >({});
+  const [districtDropdownOpen, setDistrictDropdownOpen] = useState<
+    Record<number, boolean>
+  >({});
 
   const allCities = Object.keys(locationData);
 
   const handleAddLocation = () => {
     if (locations.length < 3) {
-      setLocations([...locations, { city: '', district: '' }]);
+      setLocations([...locations, { city: "", district: "" }]);
     }
   };
 
-  const handleLocationChange = (index: number, field: 'city' | 'district', value: string) => {
+  const handleLocationChange = (
+    index: number,
+    field: "city" | "district",
+    value: string
+  ) => {
     const newLocations = [...locations];
     newLocations[index][field] = value;
-    if (field === 'city') {
-      newLocations[index].district = ''; // 시/도 변경 시 시/군/구 초기화
+    if (field === "city") {
+      newLocations[index].district = ""; // 시/도 변경 시 시/군/구 초기화
     }
     setLocations(newLocations);
-    if (field === 'city') {
+    if (field === "city") {
       setCityDropdownOpen((prev) => ({ ...prev, [index]: false }));
     } else {
       setDistrictDropdownOpen((prev) => ({ ...prev, [index]: false }));
     }
   };
 
-  const handlePartChange = (part: string) => {
+  const handlePartChange = (pos: string) => {
     setParts((prevParts) =>
-      prevParts.includes(part) ? prevParts.filter((p) => p !== part) : [...prevParts, part]
+      prevParts.includes(pos)
+        ? prevParts.filter((p) => p !== pos)
+        : [...prevParts, pos]
     );
   };
 
@@ -58,10 +71,14 @@ const Desired = () => {
       <div className="grid grid-cols-[240px_auto] gap-8">
         <div>
           <h3 className="text-lg font-semibold">지역</h3>
-          <p className="text-sm text-gray-500">선호 하는 지역을 선택해 주세요</p>
+          <p className="text-sm text-gray-500">
+            선호 하는 지역을 선택해 주세요
+          </p>
         </div>
         <div className="space-y-4 min-w-[550px]">
-          <p className="text-sm font-semibold text-gray-600">지역선택 {locations.length} / 3</p>
+          <p className="text-sm font-semibold text-gray-600">
+            지역선택 {locations.length} / 3
+          </p>
           {locations
             .slice()
             .reverse()
@@ -71,30 +88,46 @@ const Desired = () => {
                 <div key={index} className="flex items-center gap-4">
                   <div className="relative w-[280px]">
                     <SplitButton
-                      labelText={location.city || '시/도'}
+                      labelText={location.city || "시/도"}
                       onClickLeading={() => toggleCityDropdown(index)}
                       onClickTrailing={() => toggleCityDropdown(index)}
                     />
                     <CustomDropdown
                       options={allCities}
-                      onSelect={(value) => handleLocationChange(index, 'city', value)}
+                      onSelect={(value) =>
+                        handleLocationChange(index, "city", value)
+                      }
                       isOpen={cityDropdownOpen[index] || false}
-                      setIsOpen={(isOpen) => setCityDropdownOpen((prev) => ({ ...prev, [index]: isOpen }))}
+                      setIsOpen={(isOpen) =>
+                        setCityDropdownOpen((prev) => ({
+                          ...prev,
+                          [index]: isOpen,
+                        }))
+                      }
                       selectedValue={location.city}
                     />
                   </div>
                   <div className="relative w-[280px]">
                     <SplitButton
-                      labelText={location.district || '시/군/구'}
+                      labelText={location.district || "시/군/구"}
                       onClickLeading={() => toggleDistrictDropdown(index)}
                       onClickTrailing={() => toggleDistrictDropdown(index)}
                       disabled={!location.city}
                     />
                     <CustomDropdown
-                      options={location.city ? locationData[location.city] || [] : []}
-                      onSelect={(value) => handleLocationChange(index, 'district', value)}
+                      options={
+                        location.city ? locationData[location.city] || [] : []
+                      }
+                      onSelect={(value) =>
+                        handleLocationChange(index, "district", value)
+                      }
                       isOpen={districtDropdownOpen[index] || false}
-                      setIsOpen={(isOpen) => setDistrictDropdownOpen((prev) => ({ ...prev, [index]: isOpen }))}
+                      setIsOpen={(isOpen) =>
+                        setDistrictDropdownOpen((prev) => ({
+                          ...prev,
+                          [index]: isOpen,
+                        }))
+                      }
                       selectedValue={location.district}
                       searchable={true}
                     />
@@ -111,7 +144,9 @@ const Desired = () => {
                     locations.length > 1 && (
                       <button
                         className="flex w-32 cursor-pointer items-center justify-center gap-1 rounded-md border border-gray-300 bg-white py-3 text-gray-500 transition-all hover:scale-105 hover:bg-gray-100"
-                        onClick={() => setLocations(locations.filter((_, i) => i !== index))}
+                        onClick={() =>
+                          setLocations(locations.filter((_, i) => i !== index))
+                        }
                       >
                         <Minus size={16} />
                         <span>삭제</span>
@@ -132,11 +167,16 @@ const Desired = () => {
           <p className="text-sm text-gray-500">맡을 파트를 선택해 주세요</p>
         </div>
         <div className="grid grid-cols-5 gap-8 text-sm">
-          {[ '프론트엔드', '백엔드', '디자인', '기획', '홍보'].map((part) => (
-            <div key={part} className="flex items-center gap-2">
-              <button onClick={() => handlePartChange(part)} className="flex cursor-pointer items-center gap-2 text-gray-500 transition-all hover:scale-105">
-                {parts.includes(part) ? <CheckSquare /> : <Square />}
-                <span className="whitespace-nowrap">{part}</span>
+          {/* 기존 api로 position 가져오기 전 코드 */}
+          {/* {["프론트엔드", "백엔드", "디자인", "기획", "홍보"].map((part) => ( */}
+          {data?.result.positions.map((pos) => (
+            <div key={pos} className="flex items-center gap-2">
+              <button
+                onClick={() => handlePartChange(pos)}
+                className="flex cursor-pointer items-center gap-2 text-gray-500 transition-all hover:scale-105"
+              >
+                {parts.includes(pos) ? <CheckSquare /> : <Square />}
+                <span className="whitespace-nowrap">{pos}</span>
               </button>
             </div>
           ))}

--- a/src/components/mypage/edit/Save.tsx
+++ b/src/components/mypage/edit/Save.tsx
@@ -1,14 +1,23 @@
-import { Folder } from 'lucide-react';
+// components/mypage/edit/Save.tsx
+import { Folder } from "lucide-react";
 
-const Save = () => {
+export default function Save({
+  onClick,
+  disabled,
+}: {
+  onClick: () => void;
+  disabled?: boolean;
+}) {
   return (
     <div className="flex justify-center py-6">
-      <button className="flex cursor-pointer items-center justify-center gap-2 rounded-lg bg-[#68548E] px-15 py-4 text-sm font-semibold text-white transition-all hover:scale-105 hover:bg-[#59407e]">
+      <button
+        onClick={onClick}
+        disabled={disabled}
+        className="flex cursor-pointer items-center justify-center gap-2 rounded-lg bg-[#68548E] px-15 py-4 text-sm font-semibold text-white transition-all hover:scale-105 hover:bg-[#59407e] disabled:opacity-60 disabled:cursor-not-allowed"
+      >
         <Folder size={20} />
         <span>프로필 저장</span>
       </button>
     </div>
   );
-};
-
-export default Save;
+}

--- a/src/hooks/apiHooks.ts
+++ b/src/hooks/apiHooks.ts
@@ -1,21 +1,19 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { fetchRequest } from './fetchRequest';
-
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { fetchRequest } from "./fetchRequest";
 
 interface ApiQueryOptions {
-  method: 'GET';
+  method: "GET";
   endpoint: string;
   enabled?: boolean;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 interface ApiMutationOptions<_TBody = unknown, TResult = unknown> {
-  method: 'POST' | 'PUT' | 'DELETE';
+  method: "POST" | "PUT" | "DELETE";
   endpoint: string;
   onSuccess?: (data: TResult) => void;
   onError?: (error: Error) => void;
 }
-
 
 // =================================================================
 //  API 요청을 위한 커스텀 훅들
@@ -38,11 +36,11 @@ export const useApiMutation = <TBody = unknown, TResult = unknown>(
 ) => {
   const queryClient = useQueryClient();
 
-  return useMutation<TResult, Error, TBody>({
-    mutationFn: (body: TBody) =>
+  return useMutation<TResult, Error, { body?: TBody; endpoint?: string }>({
+    mutationFn: ({ body, endpoint }) =>
       fetchRequest<TResult>({
         method: options.method,
-        endpoint: options.endpoint,
+        endpoint: endpoint ?? options.endpoint, //호출 시 endpoint 우선
         body,
       }),
     onSuccess: (data) => {

--- a/src/hooks/useLogin.ts
+++ b/src/hooks/useLogin.ts
@@ -1,6 +1,6 @@
-import { useApiMutation } from './apiHooks';
-import { useAuthStore } from '../store/useAuthStore';
-import { useQueryClient } from '@tanstack/react-query';
+import { useApiMutation } from "./apiHooks";
+import { useAuthStore } from "../store/useAuthStore";
+import { useQueryClient } from "@tanstack/react-query";
 
 interface LoginRequest {
   email: string;
@@ -18,10 +18,10 @@ export const useLogin = () => {
   const setToken = useAuthStore((state) => state.setToken);
   const queryClient = useQueryClient();
   const mutation = useApiMutation<LoginRequest, LoginResponse>({
-    method: 'POST',
+    method: "POST",
     endpoint: import.meta.env.VITE_API_LOGIN_ENDPOINT,
     onError: (err) => {
-      console.error('로그인 실패:', err.message);
+      console.error("로그인 실패:", err.message);
     },
   });
 
@@ -32,26 +32,31 @@ export const useLogin = () => {
       onError?: (error: Error) => void;
     }
   ) => {
-    mutation.mutate(data, {
-      onSuccess: (res) => {
-        const token = res.result?.accessToken;
+    mutation.mutate(
+      { body: data },
+      {
+        onSuccess: (res) => {
+          const token = res.result?.accessToken;
 
-        if (!token) {
-          console.error('❗ accessToken이 응답에서 누락됨:', res);
-          callbacks?.onError?.(new Error('로그인 응답에 accessToken이 없습니다.'));
-          return;
-        }
+          if (!token) {
+            console.error("❗ accessToken이 응답에서 누락됨:", res);
+            callbacks?.onError?.(
+              new Error("로그인 응답에 accessToken이 없습니다.")
+            );
+            return;
+          }
 
-        setToken(token);
-        callbacks?.onSuccess?.();
-        queryClient.invalidateQueries({ queryKey: ['user', 'me'] });
-        // console.log('저장된 token:', token);
-        // console.log('zustand 내부 상태:', useAuthStore.getState().token);
-      },
-      onError: (err) => {
-        callbacks?.onError?.(err);
-      },
-    });
+          setToken(token);
+          callbacks?.onSuccess?.();
+          queryClient.invalidateQueries({ queryKey: ["user", "me"] });
+          // console.log('저장된 token:', token);
+          // console.log('zustand 내부 상태:', useAuthStore.getState().token);
+        },
+        onError: (err) => {
+          callbacks?.onError?.(err);
+        },
+      }
+    );
   };
 
   return {

--- a/src/hooks/usePositions.ts
+++ b/src/hooks/usePositions.ts
@@ -1,4 +1,4 @@
-import { useApiQuery } from "./apiHooks";
+import { useApiMutation, useApiQuery } from "./apiHooks";
 
 interface GetPositionResponse {
   isSuccess: boolean;
@@ -10,9 +10,57 @@ interface GetPositionResponse {
   success: boolean;
 }
 
+interface PostPositionResponse {
+  isSuccess: boolean;
+  code: string;
+  message: string;
+  result: {
+    memberName: string;
+    positionName: string;
+  };
+  success: boolean;
+}
+
+interface DeletePositionResponse {
+  isSuccess: boolean;
+  code: string;
+  message: string;
+  result: {
+    memberName: string;
+    deletePositionName: string;
+  };
+  success: boolean;
+}
+
 export const useGetPositions = () => {
   return useApiQuery<GetPositionResponse>({
     method: "GET",
     endpoint: import.meta.env.VITE_API_GET_POSITIONS_ENDPOINT,
+  });
+};
+
+export const usePostPositions = () => {
+  return useApiMutation<undefined, PostPositionResponse>({
+    method: "POST",
+    endpoint: "/api/v1/members/position", // 기본값 (호출 시 덮어씀)
+    onSuccess: (data) => {
+      alert(`포지션 ${data.result.positionName}이(가) 등록되었습니다.`);
+    },
+    onError: (error) => {
+      alert(`포지션 등록에 실패했습니다: ${error.message}`);
+    },
+  });
+};
+
+export const useDeletePositions = () => {
+  return useApiMutation<undefined, DeletePositionResponse>({
+    method: "DELETE",
+    endpoint: "/api/v1/members/position", // 기본값 (호출 시 덮어씀)
+    onSuccess: (data) => {
+      alert(`포지션 ${data.result.deletePositionName}이(가) 삭제되었습니다.`);
+    },
+    onError: (error) => {
+      alert(`포지션 삭제에 실패했습니다: ${error.message}`);
+    },
   });
 };

--- a/src/hooks/usePositions.ts
+++ b/src/hooks/usePositions.ts
@@ -1,0 +1,18 @@
+import { useApiQuery } from "./apiHooks";
+
+interface GetPositionResponse {
+  isSuccess: boolean;
+  code: string;
+  message: string;
+  result: {
+    positions: string[];
+  };
+  success: boolean;
+}
+
+export const useGetPositions = () => {
+  return useApiQuery<GetPositionResponse>({
+    method: "GET",
+    endpoint: import.meta.env.VITE_API_GET_POSITIONS_ENDPOINT,
+  });
+};

--- a/src/hooks/useProfile.ts
+++ b/src/hooks/useProfile.ts
@@ -1,0 +1,54 @@
+import { useApiQuery } from "./apiHooks";
+
+interface GetProfileResponse {
+  isSuccess: boolean;
+  code: string;
+  message: string;
+  result: {
+    profileTitle: string;
+    name: string;
+    nickname: string;
+    age: number;
+    gender: boolean; // true=남자, false=여자 (추측)
+    mbti: string;
+    school: string;
+    profileImageUrl: string;
+    email: string;
+    skills: {
+      id: number;
+      name: string;
+      skillType: string; // 필요한 경우 enum 확장
+    }[];
+    strengths: {
+      id: number;
+      name: string;
+      strengthType: string; // 필요한 경우 enum 확장
+    }[];
+    regions: {
+      id: number;
+      siDo: string; // 시/도
+      siGunGu: string; // 시/군/구
+    }[];
+    positions: string[];
+    portfolios: {
+      id: number;
+      name: string;
+      fileUrl: string;
+    }[];
+    selfIntroduce: string;
+    activities: {
+      name: string;
+      startDate: string; // YYYY-MM-DD
+      hasEndDate: boolean;
+      endDate?: string; // hasEndDate가 true일 때만 존재
+    }[];
+  };
+  success: boolean;
+}
+
+export const useGetProfile = () => {
+  return useApiQuery<GetProfileResponse>({
+    method: "GET",
+    endpoint: import.meta.env.VITE_API_GET_PROFILE_ENDPOINT,
+  });
+};

--- a/src/store/useProfileStore.ts
+++ b/src/store/useProfileStore.ts
@@ -1,0 +1,29 @@
+// store/useProfileEditStore.ts
+import { create } from "zustand";
+
+type ProfileEditStore = {
+  initialPositions: string[];
+  positions: string[];
+
+  setInitialPositions: (v: string[]) => void;
+  setPositions: (v: string[]) => void;
+  togglePosition: (pos: string) => void;
+  reset: () => void;
+};
+
+export const useProfileStore = create<ProfileEditStore>((set, get) => ({
+  initialPositions: [],
+  positions: [],
+
+  setInitialPositions: (v) => set({ initialPositions: v }),
+  setPositions: (v) => set({ positions: v }),
+  togglePosition: (pos) => {
+    const cur = get().positions;
+    set({
+      positions: cur.includes(pos)
+        ? cur.filter((p) => p !== pos)
+        : [...cur, pos],
+    });
+  },
+  reset: () => set({ initialPositions: [], positions: [] }),
+}));


### PR DESCRIPTION
## 작업내용
마이페이지 프로필부분 포지션 목록 조회해서 선택버튼 만들고
해당 포지션들을 누르면 zustand를 활용해 상태 저장 후 밑에 프로필 저장버튼을 누르면 api호출해서 적용되도록 작업 완료.
추가로 삭제 되는 로직도 이와 같음 
에러 방지를 위해 무조건 삭제하고 등록하는 과정으로 작업했습니다.

## 관련이슈
closes(#89 )